### PR TITLE
feat(cilium): add bgp

### DIFF
--- a/kubernetes/main/apps/kube-system/cilium/app/helm-values.yaml
+++ b/kubernetes/main/apps/kube-system/cilium/app/helm-values.yaml
@@ -11,6 +11,8 @@ bpf:
   masquerade: true
   preallocateMaps: true
   tproxy: true
+bgpControlPlane:
+  enabled: true
 cgroup:
   automount:
     enabled: false
@@ -68,6 +70,8 @@ securityContext:
       - IPC_LOCK
       - SYS_ADMIN
       - SYS_RESOURCE
+      - PERFMON
+      - BPF
       - DAC_OVERRIDE
       - FOWNER
       - SETGID

--- a/kubernetes/main/apps/kube-system/cilium/config/kustomization.yaml
+++ b/kubernetes/main/apps/kube-system/cilium/config/kustomization.yaml
@@ -4,3 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./l2.yaml
+  - ./l3.yaml
+  - ./pool.yaml

--- a/kubernetes/main/apps/kube-system/cilium/config/l2.yaml
+++ b/kubernetes/main/apps/kube-system/cilium/config/l2.yaml
@@ -10,15 +10,3 @@ spec:
   nodeSelector:
     matchLabels:
       kubernetes.io/os: linux
----
-# yaml-language-server: $schema=https://k8s-skeemahs.pages.dev/cilium.io/ciliumloadbalancerippool_v2alpha1.json
-apiVersion: cilium.io/v2alpha1
-kind: CiliumLoadBalancerIPPool
-metadata:
-  name: l2-pool
-spec:
-  allowFirstLastIPs: "Yes"
-  blocks:
-    - # Controller VIP: 192.168.42.120
-      start: 192.168.42.121
-      stop: 192.168.42.149

--- a/kubernetes/main/apps/kube-system/cilium/config/l3.yaml
+++ b/kubernetes/main/apps/kube-system/cilium/config/l3.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumbgppeeringpolicy_v2alpha1.json
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPPeeringPolicy
+metadata:
+  name: l3-policy
+spec:
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/os: linux
+  virtualRouters:
+    - localASN: 64514
+      exportPodCIDR: false
+      serviceSelector:
+        matchExpressions:
+          - key: thisFakeSelector
+            operator: NotIn
+            values:
+              - will-match-and-announce-all-services
+      neighbors:
+        - peerAddress: 192.168.1.1/32
+          peerASN: 64513

--- a/kubernetes/main/apps/kube-system/cilium/config/pool.yaml
+++ b/kubernetes/main/apps/kube-system/cilium/config/pool.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumloadbalancerippool_v2alpha1.json
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: pool
+spec:
+  allowFirstLastIPs: "Yes"
+  blocks:
+    - # Controller VIP: 192.168.42.120
+      start: 192.168.42.121
+      stop: 192.168.42.149


### PR DESCRIPTION
After merging, make sure the new helm values take inside Cilium. Sometimes it takes a bit since we reference them with a configmap.

Then add this file to the UDM under Routing -> BGP

bgp.conf:

```
router bgp 64513
  bgp router-id 192.168.1.1
  no bgp ebgp-requires-policy

  neighbor k8s peer-group
  neighbor k8s remote-as 64514

  neighbor 192.168.42.10 peer-group k8s
  neighbor 192.168.42.11 peer-group k8s
  neighbor 192.168.42.12 peer-group k8s

  address-family ipv4 unicast
    neighbor k8s next-hop-self
    neighbor k8s soft-reconfiguration inbound
  exit-address-family
exit
```