### PR TITLE
feat(helmfile): install prom crds via presync hook

### DIFF
--- a/.taskfiles/bootstrap/Taskfile.yaml
+++ b/.taskfiles/bootstrap/Taskfile.yaml
@@ -32,8 +32,7 @@ tasks:
       - until kubectl wait nodes --for=condition=Ready=False --all --timeout=10m; do sleep 5; done
       - op run --env-file {{.KUBERNETES_DIR}}/bootstrap/apps/.secrets.env --no-masking -- minijinja-cli {{.KUBERNETES_DIR}}/bootstrap/apps/templates/resources.yaml.j2 | kubectl apply --server-side --filename -
       - helmfile --quiet --file {{.KUBERNETES_DIR}}/bootstrap/apps/helmfile.yaml apply --skip-diff-on-install --suppress-diff
-      - for: ['prometheus-operator-crds', 'wipe-rook']
-        cmd: helmfile --quiet --file {{.KUBERNETES_DIR}}/bootstrap/apps/helmfile.yaml destroy --selector name={{.ITEM}}
+      - helmfile --quiet --file {{.KUBERNETES_DIR}}/bootstrap/apps/helmfile.yaml destroy --selector name=wipe-rook
     env:
       NODE_COUNT:
         sh: talosctl config info --output json | jq --raw-output '.nodes | length'

--- a/kubernetes/bootstrap/apps/helmfile.yaml
+++ b/kubernetes/bootstrap/apps/helmfile.yaml
@@ -15,25 +15,18 @@ repositories:
     url: https://charts.jetstack.io
 
 releases:
-  - name: prometheus-operator-crds
-    namespace: kube-system
-    chart: oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds
-    version: 18.0.0
-    values:
-      - crds:
-          annotations:
-            helm.sh/resource-policy: keep
-
   - name: cilium
     namespace: kube-system
     chart: cilium/cilium
     version: 1.17.0
     values: ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/kube-system/cilium/app/helm-values.yaml']
     hooks:
-      - events: ["postsync"]
+      - events: ['presync']
+        command: bash
+        args: ['{{ requiredEnv "KUBERNETES_DIR" }}/bootstrap/apps/scripts/cilium-presync.sh']
+      - events: ['postsync']
         command: bash
         args: ['{{ requiredEnv "KUBERNETES_DIR" }}/bootstrap/apps/scripts/cilium-postsync.sh']
-    needs: ['kube-system/prometheus-operator-crds']
 
   - name: coredns
     namespace: kube-system

--- a/kubernetes/bootstrap/apps/scripts/cilium-presync.sh
+++ b/kubernetes/bootstrap/apps/scripts/cilium-presync.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator
+PROMETHEUS_OPERATOR_VERSION="v0.80.0"
+
+install_prometheus_crds() {
+    local crds=(
+        "alertmanagerconfigs"
+        "alertmanagers"
+        "podmonitors"
+        "probes"
+        "prometheusagents"
+        "prometheuses"
+        "prometheusrules"
+        "scrapeconfigs"
+        "servicemonitors"
+        "thanosrulers"
+    )
+
+    for crd in "${crds[@]}"; do
+        kubectl apply \
+            --server-side \
+            --filename \
+            "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${PROMETHEUS_OPERATOR_VERSION}/example/prometheus-operator-crd/monitoring.coreos.com_${crd}.yaml"
+    done
+}
+
+main() {
+    install_prometheus_crds
+}
+
+main


### PR DESCRIPTION
Removes the need for installing them via helm and cleaning up the helm chart by applying it via a presync hook with kubectl