### PR TITLE
chore: release workflow only create tags

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,4 +1,0 @@
-changelog:
-  exclude:
-    authors:
-      - codewarden-bot

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -26,15 +26,15 @@ jobs:
           github-token: "${{ steps.app-token.outputs.token }}"
           result-encoding: string
           script: |
-            const { data: releases } = await github.rest.repos.listTags({
+            const { data: tags } = await github.rest.repos.listTags({
               owner: context.repo.owner,
               repo: context.repo.repo,
               per_page: 1,
             });
 
             let previousTag = "0.0.0"; // Default if no previous release exists
-            if (releases.length > 0) {
-              previousTag = releases[0].tag_name;
+            if (tags.length > 0) {
+              previousTag = tags[0].name;
             }
 
             const [previousMajor, previousMinor, previousPatch] = previousTag.split('.').map(Number);
@@ -59,9 +59,20 @@ jobs:
         with:
           github-token: "${{ steps.app-token.outputs.token }}"
           script: |
+            const tagName = "${{ steps.determine-next-tag.outputs.result }}";
+
+            const tag = await github.rest.git.createTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: tagName,
+              message: tagName,
+              object: context.sha,
+              type: "commit"
+            })
+
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: refs/tags/${{ steps.determine-next-tag.outputs.result }},
-              sha: context.sha
+              ref: `refs/tags/${tagName}`,
+              sha: tag.data.sha
             })

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: "Release"
+name: "Tag"
 
 on:
   workflow_dispatch:
@@ -8,8 +8,8 @@ on:
     - cron: "0 0 1 * *" # 1st of every month at midnight
 
 jobs:
-  release:
-    name: Release
+  tag:
+    name: Tag
     runs-on: ubuntu-latest
     steps:
       - name: Generate Token
@@ -19,14 +19,14 @@ jobs:
           app-id: "${{ secrets.BOT_APP_ID }}"
           private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
 
-      - name: Get Previous Release Tag and Determine Next Tag
+      - name: Get Previous Tag and Determine Next Tag
         id: determine-next-tag
         uses: actions/github-script@v7
         with:
           github-token: "${{ steps.app-token.outputs.token }}"
           result-encoding: string
           script: |
-            const { data: releases } = await github.rest.repos.listReleases({
+            const { data: releases } = await github.rest.repos.listTags({
               owner: context.repo.owner,
               repo: context.repo.repo,
               per_page: 1,
@@ -54,9 +54,14 @@ jobs:
 
             return `${nextMajorMinor}.${nextPatch}`;
 
-      - name: Create Release
-        uses: ncipollo/release-action@v1
+      - name: Create Tag
+        uses: actions/github-script@v7
         with:
-          generateReleaseNotes: true
-          tag: "${{ steps.determine-next-tag.outputs.result }}"
-          token: "${{ steps.app-token.outputs.token }}"
+          github-token: "${{ steps.app-token.outputs.token }}"
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: refs/tags/${{ steps.determine-next-tag.outputs.result }},
+              sha: context.sha
+            })


### PR DESCRIPTION
Releases spam peoples activity feeds and tags are pretty much only used for looking back in time for something.

The below command will remove all releases but keep existing tags.

```bash
gh release list --json name | jq -r '.[] | .name' | xargs -l bash -c 'gh release delete $0'
```