### PR TITLE
Revert "fix(container): update image ghcr.io/twin/gatus ( v5.24.1 ➔ v5.24.2 )"

### DIFF
--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -43,7 +43,7 @@ spec:
           app:
             image:
               repository: ghcr.io/twin/gatus
-              tag: v5.24.2@sha256:0e333eb7c25e3b5be93eaf94ea182a9f0c97bd69f9902fd0c5769437645dcb75
+              tag: v5.24.1@sha256:fcd3ba5a7d7db6c1c83780529cd69f249d1dff6deaffcdb6729ac804fe3d4444
             env:
               GATUS_CONFIG_PATH: /config
               GATUS_DELAY_START_SECONDS: 5


### PR DESCRIPTION
Reverts caycehouse/home-ops#2122