### PR TITLE
chore: migrate lb svc to services vlan

### DIFF
--- a/bootstrap/helmfile.d/01-apps.yaml
+++ b/bootstrap/helmfile.d/01-apps.yaml
@@ -18,7 +18,7 @@ releases:
         command: bash
         args:
           - -c
-          - until kubectl get crd ciliumloadbalancerippools.cilium.io ciliuml2announcementpolicies.cilium.io ciliumbgpadvertisements.cilium.io ciliumbgppeerconfigs.cilium.io ciliumbgpclusterconfigs.cilium.io &>/dev/null; do sleep 5; done
+          - until kubectl get crd ciliumloadbalancerippools.cilium.io ciliumbgpadvertisements.cilium.io ciliumbgppeerconfigs.cilium.io ciliumbgpclusterconfigs.cilium.io &>/dev/null; do sleep 5; done
         events:
           - postsync
         showlogs: true

--- a/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
               tag: 2025.9.4@sha256:55c7db16301626265c6c8132985137ca0798303773dafa244e562353baa93a6f
             env:
               TZ: America/New_York
-              HASS_HTTP_TRUSTED_PROXY_1: 192.168.42.0/24
+              HASS_HTTP_TRUSTED_PROXY_1: 192.168.69.0/24
               HASS_HTTP_TRUSTED_PROXY_2: 10.69.0.0/16
               HASS_INTERNAL_URL: &hass_url https://hass.housefam.casa
               HASS_EXTERNAL_URL: *hass_url

--- a/kubernetes/apps/default/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mosquitto/app/helmrelease.yaml
@@ -47,7 +47,7 @@ spec:
         type: LoadBalancer
         annotations:
           external-dns.alpha.kubernetes.io/hostname: mosquitto.housefam.casa
-          lbipam.cilium.io/ips: 192.168.42.129
+          lbipam.cilium.io/ips: 192.168.69.129
         externalTrafficPolicy: Cluster
         ports:
           http:

--- a/kubernetes/apps/default/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/default/smtp-relay/app/helmrelease.yaml
@@ -59,7 +59,7 @@ spec:
         type: LoadBalancer
         annotations:
           external-dns.alpha.kubernetes.io/hostname: smtp-relay.housefam.casa
-          lbipam.cilium.io/ips: 192.168.42.123
+          lbipam.cilium.io/ips: 192.168.69.123
         externalTrafficPolicy: Cluster
         ports:
           http:

--- a/kubernetes/apps/games/satisfactory/app/helmrelease.yaml
+++ b/kubernetes/apps/games/satisfactory/app/helmrelease.yaml
@@ -64,7 +64,7 @@ spec:
         type: LoadBalancer
         annotations:
           external-dns.alpha.kubernetes.io/hostname: satisfactory.thefryer.games
-          lbipam.cilium.io/ips: 192.168.42.130
+          lbipam.cilium.io/ips: 192.168.69.130
         externalTrafficPolicy: Cluster
         ports:
           api:

--- a/kubernetes/apps/games/valheim/app/helmrelease.yaml
+++ b/kubernetes/apps/games/valheim/app/helmrelease.yaml
@@ -78,7 +78,7 @@ spec:
         type: LoadBalancer
         annotations:
           external-dns.alpha.kubernetes.io/hostname: valheim.thefryer.games
-          lbipam.cilium.io/ips: 192.168.42.133
+          lbipam.cilium.io/ips: 192.168.69.133
         externalTrafficPolicy: Cluster
         ports:
           gameplay:

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -53,7 +53,7 @@ spec:
     kubeProxyReplacement: true
     kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
     l2announcements:
-      enabled: true
+      enabled: false
     loadBalancer:
       algorithm: maglev
       mode: dsr

--- a/kubernetes/apps/kube-system/cilium/app/networking.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networking.yaml
@@ -7,20 +7,7 @@ metadata:
 spec:
   allowFirstLastIPs: "No"
   blocks:
-    - cidr: 192.168.42.0/24
----
-# yaml-language-server: $schema=https://k8s-skeemahs.pages.dev/cilium.io/ciliuml2announcementpolicy_v2alpha1.json
-apiVersion: cilium.io/v2alpha1
-kind: CiliumL2AnnouncementPolicy
-metadata:
-  name: l2-policy
-spec:
-  loadBalancerIPs: true
-  interfaces:
-    - bond0
-  nodeSelector:
-    matchLabels:
-      kubernetes.io/os: linux
+    - cidr: 192.168.69.0/24
 ---
 # yaml-language-server: $schema=https://k8s-skeemahs.pages.dev/cilium.io/ciliumbgpadvertisement_v2.json
 apiVersion: cilium.io/v2
@@ -77,7 +64,7 @@ metadata:
   name: kube-api
   annotations:
     external-dns.alpha.kubernetes.io/hostname: k8s.housefam.casa
-    lbipam.cilium.io/ips: 192.168.42.120
+    lbipam.cilium.io/ips: 192.168.69.120
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Cluster

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -55,7 +55,7 @@ spec:
   infrastructure:
     annotations:
       external-dns.alpha.kubernetes.io/hostname: *hostname
-      lbipam.cilium.io/ips: 192.168.42.126
+      lbipam.cilium.io/ips: 192.168.69.126
   listeners:
     - name: http
       protocol: HTTP
@@ -86,7 +86,7 @@ spec:
   infrastructure:
     annotations:
       external-dns.alpha.kubernetes.io/hostname: *hostname
-      lbipam.cilium.io/ips: 192.168.42.121
+      lbipam.cilium.io/ips: 192.168.69.121
   listeners:
     - name: http
       protocol: HTTP
@@ -117,7 +117,7 @@ spec:
   infrastructure:
     annotations:
       external-dns.alpha.kubernetes.io/hostname: *hostname
-      lbipam.cilium.io/ips: 192.168.42.127
+      lbipam.cilium.io/ips: 192.168.69.127
   listeners:
     - name: http
       protocol: HTTP

--- a/kubernetes/apps/network/mc-router/app/helmrelease.yaml
+++ b/kubernetes/apps/network/mc-router/app/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
       minecraft:
         type: LoadBalancer
         annotations:
-          lbipam.cilium.io/ips: 192.168.42.140
+          lbipam.cilium.io/ips: 192.168.69.140
           external-dns.alpha.kubernetes.io/hostname: mc-router.thefryer.games
       extraServiceSpec:
         externalTrafficPolicy: Cluster

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -6,10 +6,6 @@ machine:
     {% if ENV.IS_CONTROLLER %}
     key: op://kubernetes/talos/MACHINE_CA_KEY
     {% endif %}
-  certSANs:
-    - 127.0.0.1
-    - 192.168.42.120
-    - k8s.internal
   features:
     apidCheckExtKeyUsage: true
     diskQuotaSupport: true
@@ -144,8 +140,6 @@ cluster:
       rules:
         - level: Metadata
     certSANs:
-      - 127.0.0.1
-      - 192.168.42.120
       - k8s.internal
     disablePodSecurityPolicy: true
     extraArgs:


### PR DESCRIPTION
This changes my L3 LBIPs to use a dedicated VLAN I set up in Unifi.

Apparently this should allow my nas to communicate with my cluster without using L2, we will see...

Post merge:

Update port forwarding on router for envoy-gateway-ipv4, satisfactory, and minecraft.
Update any hard coded old LB IPs in apps to the new LB IP.