### PR TITLE
chore: post flux 2.7.0 changes

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -110,3 +110,19 @@ spec:
             target:
               kind: Deployment
               name: helm-controller
+          - # Watch configmaps and secrets attached to HelmReleases and Kustomizations
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/args/-
+                value: --watch-configs-label-selector=owner!=helm
+            target:
+              kind: Deployment
+              name: (helm-controller|kustomize-controller)
+          - # Cancel health checks on new Kustomizations revisions
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/args/-
+                value: --feature-gates=CancelHealthCheckOnNewRevision=true
+            target:
+              kind: Deployment
+              name: kustomize-controller

--- a/kubernetes/components/defaults/kustomization.yaml
+++ b/kubernetes/components/defaults/kustomization.yaml
@@ -12,12 +12,11 @@ patches:
         path: /spec/install
         value:
           crds: CreateReplace
-          remediation:
-            retries: -1
+          strategy:
+            name: RetryOnFailure
       - op: add
         path: /spec/upgrade
         value:
-          cleanupOnFail: true
           crds: CreateReplace
-          remediation:
-            retries: 3
+          strategy:
+            name: RetryOnFailure


### PR DESCRIPTION
Waiting on Flux 2.7.0

Steps:

1. Upgrade Flux to 2.7.0
2. Verify it's rolled out
3. Merge this PR
4. Test/Verify