### PR TITLE
chore: update kustomization defaults

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -27,9 +27,6 @@ spec:
         ref: refs/heads/main
         path: kubernetes/flux/cluster
         interval: 1h
-      commonMetadata:
-        labels:
-          app.kubernetes.io/name: flux
       kustomize:
         patches:
           - # Increase the number of workers

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -6,36 +6,24 @@ metadata:
   name: cluster-apps
   namespace: flux-system
 spec:
+  deletionPolicy: WaitForTermination
   interval: 1h
   path: ./kubernetes/apps
   prune: true
-  retryInterval: 2m
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  timeout: 10m
   wait: false
   patches:
-    - # Add default timings to all Kustomizations
+    - # Add Kustomization defaults for all child Kustomizations
       patch: |-
         apiVersion: kustomize.toolkit.fluxcd.io/v1
         kind: Kustomization
         metadata:
           name: not-used
         spec:
-          retryInterval: 2m
-          timeout: 10m
-      target:
-        group: kustomize.toolkit.fluxcd.io
-        kind: Kustomization
-    - # Add HelmRelease defaults to all Kustomizations
-      patch: |-
-        apiVersion: kustomize.toolkit.fluxcd.io/v1
-        kind: Kustomization
-        metadata:
-          name: not-used
-        spec:
+          deletionPolicy: WaitForTermination
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -50,7 +38,6 @@ spec:
                   rollback:
                     cleanupOnFail: true
                     recreate: true
-                  timeout: 10m
                   upgrade:
                     cleanupOnFail: true
                     crds: CreateReplace


### PR DESCRIPTION
let's prove this out over time...

- consolidate ks patch for children
- remove timeouts and retryInterval (not needed with 2.7.0 and patch to cancel pending ks healthchecks?)
- add WaitForTermination deletionPolicy (fix for alerts on ks removal?)