### PR TITLE
feat(ha-mcp): add Home Assistant MCP server

### DIFF
--- a/kubernetes/apps/default/ha-mcp/app/externalsecret.yaml
+++ b/kubernetes/apps/default/ha-mcp/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ha-mcp
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: ha-mcp-secret
+    template:
+      data:
+        HOMEASSISTANT_TOKEN: "{{ .HOMEASSISTANT_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: ha-mcp

--- a/kubernetes/apps/default/ha-mcp/app/helmrelease.yaml
+++ b/kubernetes/apps/default/ha-mcp/app/helmrelease.yaml
@@ -1,0 +1,72 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ha-mcp
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: ha-mcp
+  interval: 1h
+  values:
+    controllers:
+      ha-mcp:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/homeassistant-ai/ha-mcp
+              tag: 7.7.0@sha256:9e5e9c64f5da5e07991ba7d2ee28a8f1a4b751d89daadb1a73e1546625eece11
+            command: ["ha-mcp-web"]
+            env:
+              HOMEASSISTANT_URL: http://home-assistant.default.svc.cluster.local:8123
+              MCP_PORT: &port 80
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.housefam.casa"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    persistence:
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/default/ha-mcp/app/kustomization.yaml
+++ b/kubernetes/apps/default/ha-mcp/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/ha-mcp/app/ocirepository.yaml
+++ b/kubernetes/apps/default/ha-mcp/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: ha-mcp
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/ha-mcp/ks.yaml
+++ b/kubernetes/apps/default/ha-mcp/ks.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ha-mcp
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/default/ha-mcp/app
+  postBuild:
+    substitute:
+      APP: ha-mcp
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./changedetection/ks.yaml
   - ./free-games-claimer/ks.yaml
   - ./freshrss/ks.yaml
+  - ./ha-mcp/ks.yaml
   - ./home-assistant/ks.yaml
   - ./isponsorblocktv/ks.yaml
   - ./linkding/ks.yaml


### PR DESCRIPTION
Stand up ha-mcp (homeassistant-ai/ha-mcp) in the default namespace, alongside home-assistant. Stateless app-template deployment that bridges MCP clients to Home Assistant over the in-cluster service, exposed on an internal envoy route. Reaches HA at
http://home-assistant.default.svc.cluster.local:8123 with a long-lived token from 1Password (ha-mcp-secret).