### PR TITLE
fix(default): trigger FGC VolSync restore eagerly on cluster reset

### DIFF
--- a/kubernetes/apps/default/free-games-claimer/app/kustomization.yaml
+++ b/kubernetes/apps/default/free-games-claimer/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./pvc-init-job.yaml

--- a/kubernetes/apps/default/free-games-claimer/app/pvc-init-job.yaml
+++ b/kubernetes/apps/default/free-games-claimer/app/pvc-init-job.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/batch/job_v1.json
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: free-games-claimer-pvc-init
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+spec:
+  ttlSecondsAfterFinished: 60
+  template:
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: init
+          image: ghcr.io/home-operations/busybox:1.38.0@sha256:7e2c04dd50ede647bf4a7a4c8dbd629dd4971cd139b9b88fb22bfc3c7a6c13df
+          command: ["/bin/sh", "-c", "echo pvc ready"]
+          volumeMounts:
+            - name: data
+              mountPath: /fgc/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: free-games-claimer


### PR DESCRIPTION
## Summary

- Adds a one-shot Job (`pvc-init-job.yaml`) to the `free-games-claimer` app that mounts the FGC PVC and immediately exits
- Registers it in `kustomization.yaml`

## Why

VolSync's volume populator is **lazy** — it only runs the restore job when a Pod actually tries to mount the PVC. After a cluster reset, the PVC sits in `Pending` until FGC's noon CronJob fires its first pod. In the meantime, the ReplicationSource fires on its 2-hour schedule, tries to snapshot the still-Pending PVC, fails, and AlertManager raises `VolSyncVolumeOutOfSync` for up to ~12 hours.

The one-shot Job eagerly triggers the populator at cluster startup, so the restore completes and the PVC binds before the first ReplicationSource window hits.

## Implementation notes

- `kustomize.toolkit.fluxcd.io/ssa: IfNotPresent` — Flux SSA skips the Job if it already exists, making it fire only on a fresh/reset cluster
- `ttlSecondsAfterFinished: 60` — self-cleans after completion
- Uses `ghcr.io/home-operations/busybox` already pinned in the repo (mutatingadmissionpolicy.yaml)

Closes #3078