### PR TITLE
docs: document application and PR MCP tools in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,14 @@ For runtime, reconciliation, deployment, or incident questions, use the LiteLLM 
 
 Use these read-only tools automatically when relevant. Do not perform cluster mutations unless the user explicitly requests them.
 
+The cluster also hosts MCP servers for its applications and PR workflow — reach for these when the task calls for them (not for cluster investigation):
+
+- `konflate-*` — inspect open Renovate/bot PRs (list, diff, summary); pairs with the `merge-renovate-prs` skill.
+- `ha_mcp-*` — read and control Home Assistant (entities, automations, scripts, dashboards). Treat state changes as mutations: confirm before acting.
+- `actual_mcp-*` — query and modify the Actual Budget ledger (accounts, transactions, budgets). Treat writes as mutations: confirm before acting.
+
+All six MCP servers live under `kubernetes/apps/ai/<name>-mcp/` and register with the LiteLLM proxy in `kubernetes/apps/ai/litellm/`; each tool's prefix is the server's `spec.alias`.
+
 ## Architecture
 
 ### Flux reconciliation flow


### PR DESCRIPTION
## What

Adds the three MCP tool families the LiteLLM proxy exposes that weren't documented in `AGENTS.md`'s **Live-system investigation** section — it previously listed only the cluster-ops tools (`flux-*`, `victoria_logs-*`, `grafana-*`).

Now also documents:
- `konflate-*` — Renovate/bot PR inspection (list, diff, summary); pairs with the `merge-renovate-prs` skill.
- `ha_mcp-*` — Home Assistant read/control, with a mutation-safety caveat.
- `actual_mcp-*` — Actual Budget ledger query/modify, with a mutation-safety caveat.

Plus a pointer that all six servers now live under `kubernetes/apps/ai/<name>-mcp/` (per the recent split in #3394) and register with the proxy in `kubernetes/apps/ai/litellm/`, with each tool prefix matching the server's `spec.alias`.

## Why

Follow-up to #3394 — the split reorganized where the MCP servers are defined, and half of them were never listed in the agent guidance. This keeps `AGENTS.md` an accurate, complete map of the available tools.

Docs-only; edits `AGENTS.md` (the target of the `CLAUDE.md` symlink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)